### PR TITLE
Azure healthcheck backend pool fault

### DIFF
--- a/tellapart/aurproxy/app/lifecycle.py
+++ b/tellapart/aurproxy/app/lifecycle.py
@@ -66,7 +66,7 @@ def check_health():
   Returns:
     A tuple of (success, message).
   """
-  logger.info('Executing health check handlers.')
+  logger.info('Executing {} health check handlers.'.format(len(_HEALTHCHECK_HANDLERS)))
   for handler in _HEALTHCHECK_HANDLERS:
     result, message = handler()
     if not result:

--- a/tellapart/aurproxy/command.py
+++ b/tellapart/aurproxy/command.py
@@ -22,7 +22,9 @@ import json
 import logging
 
 from tellapart.aurproxy.app.module.http import lifecycle_blueprint
-from tellapart.aurproxy.app.lifecycle import register_shutdown_handler
+from tellapart.aurproxy.app.lifecycle import (
+  register_healthcheck_handler,
+  register_shutdown_handler)
 from tellapart.aurproxy.metrics.store import (
   add_publisher,
   set_root_prefix)
@@ -168,6 +170,7 @@ def run(management_port,
         registerer = load_cli_plugin(registration_class, registration_arg)
         registerer.add()
         register_shutdown_handler(registerer.remove)
+        register_healthcheck_handler(registerer.checker())
       except Exception:
         logger.exception('Registration failure.')
         raise

--- a/tellapart/aurproxy/command.py
+++ b/tellapart/aurproxy/command.py
@@ -170,7 +170,7 @@ def run(management_port,
         registerer = load_cli_plugin(registration_class, registration_arg)
         registerer.add()
         register_shutdown_handler(registerer.remove)
-        register_healthcheck_handler(registerer.checker())
+        register_healthcheck_handler(registerer.check)
       except Exception:
         logger.exception('Registration failure.')
         raise

--- a/tellapart/aurproxy/register/azurelb.py
+++ b/tellapart/aurproxy/register/azurelb.py
@@ -24,6 +24,8 @@ from tellapart.aurproxy.register.base import (
 )
 from tellapart.aurproxy.util import get_logger
 
+from time import time
+
 logger = get_logger(__name__)
 
 class AzureException(BaseException): pass
@@ -234,6 +236,10 @@ class AzureGatewaySelfRegisterer(AzureRegisterer):
     super(AzureGatewaySelfRegisterer, self).__init__(
         region, subscription_id, tenant_id, client_id, client_secret)
     self._lb_names = lb_names.split(',')
+    self._refresh_interval_secs = 60
+    self._last_checked = 0
+    self._last_result = False
+    self._check_states = [False for lb in self._lb_names]
 
   @property
   def lbs(self):
@@ -358,9 +364,10 @@ class AzureGatewaySelfRegisterer(AzureRegisterer):
     """
     instance_id = self.get_current_instance_id()
     vm = self.get_current_machine()
-    for lb in self.lbs:
+    for i, lb in enumerate(self.lbs):
       # Note: This only finds the VM in one of the balancer's backend pools
       match = self.match_load_balancer_and_vm(lb, vm)
+      logger.info("add:: lb {} had result: {}".format(i, match))
       if not match:
         self.record(lb.name,
                     instance_id,
@@ -370,11 +377,33 @@ class AzureGatewaySelfRegisterer(AzureRegisterer):
             raise AzureException("failed to register vm {} with lb {}".format(vm, lb))
         else:
             logger.info("registered vm {} with lb {}".format(vm, lb))
+            self._check_states[i] = True
       else:
         self.record(lb.name,
                     instance_id,
                     RegistrationAction.NONE,
                     [RegistrationActionReason.ALREADY_REGISTERED])
+
+
+  def check(self):
+    """
+    Return current 'registration' status as a boolean.
+    This state may change at a frequency less often than itself is called.
+    """
+    now = time()
+    if not self._last_result or self._last_checked < (now - self._refresh_interval_secs):
+        logger.info("running actual check of registration state")
+        instance_id = self.get_current_instance_id()
+        vm = self.get_current_machine()
+        for i, lb in enumerate(self.lbs):
+            self._check_states[i] = (self.match_load_balancer_and_vm(lb, vm) is not None)
+
+        self._last_checked = now
+
+    self._last_result = next(iter([x for x in self._check_states if x is True]), False)
+
+    return self._last_result, 'Last check at epoch: {}'.format(self._last_checked)
+
 
   def remove(self):
     """

--- a/tellapart/aurproxy/register/azurelb.py
+++ b/tellapart/aurproxy/register/azurelb.py
@@ -400,7 +400,7 @@ class AzureGatewaySelfRegisterer(AzureRegisterer):
 
         self._last_checked = now
 
-    self._last_result = next(iter([x for x in self._check_states if x is True]), False)
+    self._last_result = (self._check_states.count(True) > 0)
 
     return self._last_result, 'Last check at epoch: {}'.format(self._last_checked)
 

--- a/tellapart/aurproxy/register/base.py
+++ b/tellapart/aurproxy/register/base.py
@@ -44,6 +44,16 @@ class BaseRegisterer(object):
   def remove(self):
     raise NotImplementedError('remove')
 
+  def checker(self):
+    """
+    Returns a function that when called will return True or False
+    depending on whether the registerer's effect of calling add is still true
+
+    This function may cache or determine its own cadence for determining state
+    since it may be called more frequently than desired.
+    """
+    return lambda: True
+
   def synchronize(self, write):
     raise NotImplementedError('synchronize')
 

--- a/tellapart/aurproxy/register/base.py
+++ b/tellapart/aurproxy/register/base.py
@@ -44,15 +44,15 @@ class BaseRegisterer(object):
   def remove(self):
     raise NotImplementedError('remove')
 
-  def checker(self):
+  def check(self):
     """
-    Returns a function that when called will return True or False
-    depending on whether the registerer's effect of calling add is still true
+    Returns True or False depending on whether the registerer's
+    effect of calling add is still true.
 
     This function may cache or determine its own cadence for determining state
     since it may be called more frequently than desired.
     """
-    return lambda: True
+    return True, 'OK'
 
   def synchronize(self, write):
     raise NotImplementedError('synchronize')


### PR DESCRIPTION
## Description

Add a health check to an aurproxy registrar. The azure application gateway is only enabled since its hypothesized that over time sometimes instances are removed (via Azure by fault or some instance health failure) from the backend pool for unknown reasons. This health check will fail after its noticed that the instance is no longer in the backend pool, which would prompt a restart from aurora and presumably successful (re)registration into the pool.

JIRA Ticket: https://amperity.atlassian.net/browse/STUR-2221

## Changes

Added the method in the Registrater interface/base class, with default implementation.
The app gateway implementation caches the state for a minute so frequent health checks don't result in Azure api throttling or similar bad behavior. I could see the use of making this value configurable.

The check supports the hypothetical 1:N aurproxy:load balancer connection (more than one configured `lb_names` parameter), failing the health check only if all loadbalancers fail. This attempts to "gracefully" degrade since at least some would still be connected/serving.

## Testing

Locally against az-stage, running aurproxy locally with the handy bin/aurproxy script + configuration from az-stage spark + instance id from an unattached mesos executor.

Observed (`watch curl -i http://127.0.0.1:32145/health` where 32145 is the configured maintenance port):
  Startup, not attached to backend pool. Notices needs to be added to pool, add self, health check eventually passes after this happens.
  Startup, attached to backend pool. Notices nothing to be done, health check passes.
  While running, manually remove instance from backend pool (in azure portal), after about a minute of serving stale state, health check prompts a query which then results in health check failure.