### PR TITLE
add document-serving root configuration from context

### DIFF
--- a/templates/nginx/nginx.conf.template
+++ b/templates/nginx/nginx.conf.template
@@ -134,6 +134,14 @@ http {
         proxy_set_header  X-Real-IP       $remote_addr;
         proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header  Connection      "";
+
+        {% for document in context.document_roots %}
+        location {{document.location}} {
+           root {{document.root}};
+           autoindex off;
+        }
+        {%- endfor %}
+
         {% for route in server.routes %}
         {% for location in route.locations %}
         location {{location}} {


### PR DESCRIPTION

eg, --config {,,, "context": {"document_roots": [{"location": "/", "root": "/Users/colin/dev/amperity/aurproxy/"}]}

generates a location with indexing turned off (no file listing)
that will just serve documents

practically speaking this is how we can serve our
SPA + assets instead of a separate 'service'