### PR TITLE
register with 'new' elb v2 target groups

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 azure==4.0.0
 boto==2.34.0
+boto3==1.9.188
 commandr==1.3.2
 Flask-RESTful==0.3.5
 gevent==1.0.2

--- a/tellapart/aurproxy/register/aws.py
+++ b/tellapart/aurproxy/register/aws.py
@@ -20,6 +20,9 @@ __copyright__ = 'Copyright (C) 2015 TellApart, Inc. All Rights Reserved.'
 import boto.ec2
 import boto.ec2.elb
 import boto.route53
+
+import boto3
+
 import requests
 
 from tellapart.aurproxy.register.base import BaseRegisterer
@@ -155,6 +158,15 @@ class BotoConnectionManager(object):
     if not getattr(self, '_elb', None):
       self._elb = self._make_conn(boto.ec2.elb)
     return self._elb
+
+  @property
+  def elbv2(self):
+    """
+    A boto3 ELBV2 connection.
+    """
+    if not getattr(self, '_elbv2', None):
+      self._elbv2 = boto3.client('elbv2', region_name=self._region, aws_access_key_id=self._access_key, aws_secret_access_key=self._secret_key)
+    return self._elbv2
 
   @property
   def route53(self):

--- a/tellapart/aurproxy/register/elbv2.py
+++ b/tellapart/aurproxy/register/elbv2.py
@@ -1,0 +1,55 @@
+"""Registration implementation for AWS V2 Elastic Load Balancers.
+"""
+
+from tellapart.aurproxy.register.aws import AwsRegisterer
+from tellapart.aurproxy.register.base import (
+  RegistrationAction,
+  RegistrationActionReason
+)
+from tellapart.aurproxy.util import get_logger
+
+logger = get_logger(__name__)
+
+
+class ElbSelfRegisterer(AwsRegisterer):
+  """
+  Registerer that adds and removes current machine from configured ELB target group.
+  """
+
+  def __init__(self, target_group_arn, region, access_key=None, secret_key=None):
+    """
+    Common code for ELB V2 Registerers.
+
+    Args:
+      target_group_arn - str - ARN for target group to register with.
+      region - str - AWS region (EG: 'us-east-1').
+      access_key - str - Optional AWS access key.
+      secret_key - str - Optional AWS secret key.
+    """
+    super(ElbSelfRegisterer, self).__init__(region, access_key, secret_key)
+    self._target_group_arn = target_group_arn
+
+
+  def add(self):
+    """
+    Add the current instance to configured ELB Target Group.
+    Assumes that this code is running on an EC2 instance.
+    """
+    instance_id = self.get_current_instance_id()
+    self.conn.elbv2.register_targets(TargetGroupArn=self._target_group_arn,
+                                     Targets=[{'Id': instance_id}])
+    self.record(self._target_group_arn,
+                instance_id,
+                RegistrationAction.REGISTER)
+
+  def remove(self):
+    """
+    Remove the current instance from all configured ELBs.
+    Assumes that this code is running on an EC2 instance.
+    """
+    instance_id = self.get_current_instance_id()
+    self.conn.elbv2.deregister_targets(TargetGroupArn=self._target_group_arn,
+                                       Targets=[{'Id': instance_id}])
+    self.record(self._target_group_arn,
+                instance_id,
+                RegistrationAction.REMOVE)

--- a/tellapart/aurproxy/register/elbv2.py
+++ b/tellapart/aurproxy/register/elbv2.py
@@ -42,6 +42,7 @@ class ElbSelfRegisterer(AwsRegisterer):
                 instance_id,
                 RegistrationAction.REGISTER)
 
+
   def remove(self):
     """
     Remove the current instance from all configured ELBs.


### PR DESCRIPTION
# Context

To support deploying aurproxy instances that register themselves with AWS Application Load Balancers which support HTTP/2 and quite a few bell, whistles, improvements, etc.

This uses boto3 selectively since elbv2 is not available in the previous major version (2).

# Changes

Add new ElbRegisterer, update 'base' aws class with elbv2 client from boto3, without any 'upgrade' of existing libraries.

The api for (de)registering targets into target groups appears to be "upsert" and "fortuitous deletion". If instance already exists on register, no change no error. If the instance is already gone or was never registered, deregister does not throw an error. This lets the add/remove check be pretty simple and just call the api instead of (tiresomely) checking first with some kind of list api.

# Testing

Tried it out by faking get_instance_id to return a known instance of a dev aurora executor in aws-dev, then ran

```bash
./bin/aurproxy run -m 34561 --conf file://conf.json --registration-arg=region=us-west-2 --registration-arg=target_group_arn='arn:aws:elasticloadbalancing:us-west-2:485692797166:targetgroup/amperity-web-tg-dev/91c174eb62439080' --registration-class=tellapart.aurproxy.register.elbv2.ElbSelfRegisterer
```

Since keyboard-interrupt does shutdown hooks, I was able to test that the instance was successfully deregistered when aurproxy was shutting down.