### PR TITLE
always allow localhost to enable aurproxy-internal processing

### DIFF
--- a/templates/nginx/nginx.conf.template
+++ b/templates/nginx/nginx.conf.template
@@ -60,7 +60,10 @@ http {
         location /aurproxy/status {
             stub_status on;
             access_log on;
-            allow {{ context.internal_source_cidr or 127.0.0.1 }};
+            {% if context.internal_source_cidr %}
+            allow {{ context.internal_source_cidr }};
+            {%- endif %}
+            allow 127.0.0.1;
             deny all;
         }
     }


### PR DESCRIPTION
Some part of the code uses the output of the stats block and
fails when its not authorized to read itself

Surfaced as 

```
127.0.0.1 (-) - - [21/Apr/2020:05:01:05 +0000]  "GET /aurproxy/status HTTP/1.1" 403 37 "-" "python-requests/2.23.0" "localhost" 0.000 - "-" 1587445265.847
...
2020-04-21 05:03:06,051 [ERROR] tellapart.aurproxy.backends.nginx.metrics: Failed fetch proxy metrics for http://localhost:31764/aurproxy/status. Status code: 403
2020-04-21 05:03:06,051 [ERROR] tellapart.aurproxy.backends.nginx.metrics: Failed to fetch proxy metrics for http://localhost:31764/aurproxy/status.
Traceback (most recent call last):
  File "tellapart/aurproxy/backends/nginx/metrics.py", line 63, in publish
    active = int(self._ACTIVE_CONNECTIONS_RE.match(lines[0]).group('conn'))
AttributeError: 'NoneType' object has no attribute 'group'
```

So, restore this authorization.