### PR TITLE
Add context controls for gzip types

### DIFF
--- a/templates/nginx/nginx.conf.template
+++ b/templates/nginx/nginx.conf.template
@@ -38,7 +38,13 @@ http {
     access_log /dev/stdout combined_forwarded_ip;
     error_log stderr;
 
+    {% if context.gzip -%}
     gzip on;
+    gzip_proxied any;
+    {% if context.gzip_types -%}
+    gzip_types {% for type in context.gzip_types %}{{ type }}{% if not loop.last%} {% endif %}{% endfor %};
+    {%- endif %}
+    {%- endif %}
 
     # Strip nginx version from headers & error pages
     server_tokens off;


### PR DESCRIPTION
We have `gzip on` enabled in the Aurproxy nginx config, but by default [nginx only compresses `text/html` responses](https://docs.nginx.com/nginx/admin-guide/web-server/compression/). The bulk of our traffic is downloading the Javascript application bundle and the API responses, neither of which benefit from the current configuration.

This PR adds two new context settings to control the gzip behavior - `context.gzip` for overall control of compression, and `context.gzip_types` to set the list of MIME types to compress.

See: http://nginx.org/en/docs/http/ngx_http_gzip_module.html