### PR TITLE
Add support for a proxied route path

### DIFF
--- a/tellapart/aurproxy/backends/backend.py
+++ b/tellapart/aurproxy/backends/backend.py
@@ -129,9 +129,13 @@ class ProxyBackend(object):
                                               proxy_overflow_sources,
                                               overflow_threshold_pct,
                                               self._signal_update_fn,)
+    proxy_path = self._load_config_item('proxy_path', route, required=False)
 
     return ProxyRoute(
-        locations, empty_endpoint_status_code, source_group_manager)
+        locations,
+        empty_endpoint_status_code,
+        source_group_manager,
+        proxy_path)
 
   def _load_proxy_sources(self, sources):
     proxy_sources = []

--- a/tellapart/aurproxy/config/route.py
+++ b/tellapart/aurproxy/config/route.py
@@ -16,10 +16,12 @@ class ProxyRoute(object):
   def __init__(self,
                locations,
                empty_endpoint_status_code,
-               source_group_manager):
+               source_group_manager,
+               proxy_path):
     self._locations = locations
     self._empty_endpoint_status_code = empty_endpoint_status_code
     self._source_group_manager = source_group_manager
+    self._proxy_path = proxy_path
 
   @property
   def blueprints(self):
@@ -36,6 +38,10 @@ class ProxyRoute(object):
   @property
   def empty_endpoint_status_code(self):
     return self._empty_endpoint_status_code
+
+  @property
+  def proxy_path(self):
+    return self._proxy_path
 
   @property
   def slug(self):

--- a/templates/nginx/nginx.conf.template
+++ b/templates/nginx/nginx.conf.template
@@ -148,7 +148,7 @@ http {
         location {{location}} {
             {% if route.endpoints %}
             proxy_next_upstream off;
-            proxy_pass http://{{ server.slug }}{{ route.slug }};
+            proxy_pass http://{{ server.slug }}{{ route.slug }}{{ route.proxy_path or "" }};
             {% else %}
             # No endpoints found for {{ server.slug }}{{ route.slug }}
             access_log on;


### PR DESCRIPTION
We need support for remapping a proxied route to a sub-path in a backend source. This PR adds support for a new `proxy_path` field on the `ProxyRoute` class, which can be used to set this in the templated nginx config.