### PR TITLE
Forward client 'Connection' header instead of setting to empty string

### DIFF
--- a/templates/nginx/nginx.conf.template
+++ b/templates/nginx/nginx.conf.template
@@ -143,7 +143,7 @@ http {
         proxy_set_header  Host            $host;
         proxy_set_header  X-Real-IP       $remote_addr;
         proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header  Connection      "";
+        proxy_set_header  Connection      $http_connection;
         {% for route in server.routes %}
         {% for location in route.locations %}
         location {{location}} {

--- a/templates/nginx/nginx.conf.template
+++ b/templates/nginx/nginx.conf.template
@@ -143,7 +143,6 @@ http {
         proxy_set_header  Host            $host;
         proxy_set_header  X-Real-IP       $remote_addr;
         proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header  Connection      $http_connection;
         {% for route in server.routes %}
         {% for location in route.locations %}
         location {{location}} {


### PR DESCRIPTION
Aurproxy is removing the required headers for upgrading to a websocket. It looks like previous versions of netty/aleph don't care but newer versions do. 

[Slack thread for context](https://amperity.slack.com/archives/C06JUQSKHBL/p1712592080033759)

Relates to https://github.com/amperity/app/pull/42985