### PR TITLE
Try forwarding $http_connection header

### DIFF
--- a/templates/nginx/nginx.conf.template
+++ b/templates/nginx/nginx.conf.template
@@ -143,6 +143,7 @@ http {
         proxy_set_header  Host            $host;
         proxy_set_header  X-Real-IP       $remote_addr;
         proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header  Connection      $http_connection;
         {% for route in server.routes %}
         {% for location in route.locations %}
         location {{location}} {

--- a/templates/nginx/nginx.conf.template
+++ b/templates/nginx/nginx.conf.template
@@ -144,6 +144,7 @@ http {
         proxy_set_header  X-Real-IP       $remote_addr;
         proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header  Connection      $http_connection;
+        proxy_set_header  Upgrade         $http_upgrade;
         {% for route in server.routes %}
         {% for location in route.locations %}
         location {{location}} {


### PR DESCRIPTION
Removing the `proxy_set_header` directive for `Connection` is not working so lets try forwarding the `$http_connection`