### PR TITLE
Nginx limit_req support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Newer python base images may break gevent.
 # See https://github.com/docker-library/python/issues/29#issuecomment-70727289
-FROM ubuntu:xenial
+FROM --platform=linux/amd64 ubuntu:xenial
 MAINTAINER colin@amperity.com
 
 

--- a/templates/nginx/nginx.conf.template
+++ b/templates/nginx/nginx.conf.template
@@ -57,6 +57,12 @@ http {
     # From http://lxr.nginx.org/source/src/http/ngx_http_special_response.c
     error_page 400 401 402 403 404 405 406 408 409 410 411 412 413 414 415 416 494 495 496 497 500 501 502 503 504 507 /aurproxy_error.html;
 
+    {% if context.ratelimit_zones %}
+    {% for zone in context.ratelimit_zones %}
+    limit_req_zone {{ zone.key | default('$binary_remote_addr') }} zone={{ zone.name }}:{{ zone.size | default('10m') }} rate={{ zone.rate }}r/s;
+    {%- endfor %}
+    {%- endif %}
+
     {% if stats_port %}
     server {
         listen {{ stats_port }};
@@ -148,6 +154,9 @@ http {
         {% for route in server.routes %}
         {% for location in route.locations %}
         location {{location}} {
+            {% if route.ratelimit_zone %}
+            limit_req zone={{ route.ratelimit_zone }}{% if route.ratelimit_burst %} burst={{ route.ratelimit_burst }}{% endif %}{% if route.ratelimit_delay %} delay={{ route.ratelimit_delay }}{% endif %}{% if route.ratelimit_nodelay %} nodelay{% endif %};
+            {% endif %}
             {% if route.endpoints %}
             proxy_next_upstream off;
             proxy_pass http://{{ server.slug }}{{ route.slug }}{{ route.proxy_path or "" }};

--- a/templates/nginx/nginx.conf.template
+++ b/templates/nginx/nginx.conf.template
@@ -156,6 +156,7 @@ http {
         location {{location}} {
             {% if route.ratelimit_zone %}
             limit_req zone={{ route.ratelimit_zone }}{% if route.ratelimit_burst %} burst={{ route.ratelimit_burst }}{% endif %}{% if route.ratelimit_delay %} delay={{ route.ratelimit_delay }}{% endif %}{% if route.ratelimit_nodelay %} nodelay{% endif %};
+            limit_req_status {{ route.ratelimit_status | default(429) }};
             {% endif %}
             {% if route.endpoints %}
             proxy_next_upstream off;


### PR DESCRIPTION
This PR adds support for nginx's [http_limit_req](http://nginx.org/en/docs/http/ngx_http_limit_req_module.html) module, which allows for basic rate-limiting controls to be added to the proxy. This is accomplished by defining `ratelimit_zones` in the `NginxContext` template object, each of which configures one of the shared memory zones that requests are tracked in. Then, each location can have ratelimit parameters set, minimally `ratelimit_zone`.

I'm working on testing the new config out locally with docker. Not sure what's up with CI, haven't investigated that yet.