### PR TITLE
Plumb ratelimit config through Aurproxy loading

### DIFF
--- a/tellapart/aurproxy/backends/backend.py
+++ b/tellapart/aurproxy/backends/backend.py
@@ -131,11 +131,28 @@ class ProxyBackend(object):
                                               self._signal_update_fn,)
     proxy_path = self._load_config_item('proxy_path', route, required=False)
 
+    ratelimit = self._load_config_item('ratelimit', route, required=False)
+    proxy_ratelimit = self._load_proxy_ratelimit(ratelimit) if ratelimit else None
+
     return ProxyRoute(
         locations,
         empty_endpoint_status_code,
         source_group_manager,
-        proxy_path)
+        proxy_path,
+        proxy_ratelimit)
+
+  def _load_proxy_ratelimit(self, ratelimit):
+    zone = self._load_config_item('zone', ratelimit, required=True)
+    burst = self._load_config_item('burst', ratelimit, required=False)
+    delay = self._load_config_item('delay', ratelimit, required=False)
+    nodelay = self._load_config_item('nodelay', ratelimit, required=False, default=False)
+    status = self._load_config_item('status', ratelimit, required=False)
+    return ProxyRatelimit(
+        zone,
+        burst,
+        delay,
+        nodelay,
+        status)
 
   def _load_proxy_sources(self, sources):
     proxy_sources = []

--- a/tellapart/aurproxy/config/route.py
+++ b/tellapart/aurproxy/config/route.py
@@ -17,11 +17,17 @@ class ProxyRoute(object):
                locations,
                empty_endpoint_status_code,
                source_group_manager,
-               proxy_path):
+               proxy_path,
+               ratelimit=None):
     self._locations = locations
     self._empty_endpoint_status_code = empty_endpoint_status_code
     self._source_group_manager = source_group_manager
     self._proxy_path = proxy_path
+    self._ratelimit = ratelimit
+
+  @property
+  def slug(self):
+    return self._source_group_manager.slug
 
   @property
   def blueprints(self):
@@ -44,8 +50,42 @@ class ProxyRoute(object):
     return self._proxy_path
 
   @property
-  def slug(self):
-    return self._source_group_manager.slug
+  def ratelimit(self):
+    return self._ratelimit
 
   def start(self, weight_adjustment_start):
     self._source_group_manager.start(weight_adjustment_start)
+
+
+class ProxyRatelimit(object):
+  def __init__(self,
+               zone,
+               burst=None,
+               delay=None,
+               nodelay=False,
+               status=None):
+    self._zone = zone
+    self._burst = burst
+    self._delay = delay
+    self._nodelay = nodelay
+    self._status = status
+
+  @property
+  def zone(self):
+    return self._zone
+
+  @property
+  def burst(self):
+    return self._burst
+
+  @property
+  def delay(self):
+    return self._delay
+
+  @property
+  def nodelay(self):
+    return self._nodelay
+
+  @property
+  def status(self):
+    return self._status

--- a/templates/nginx/nginx.conf.template
+++ b/templates/nginx/nginx.conf.template
@@ -154,9 +154,9 @@ http {
         {% for route in server.routes %}
         {% for location in route.locations %}
         location {{location}} {
-            {% if route.ratelimit_zone %}
-            limit_req zone={{ route.ratelimit_zone }}{% if route.ratelimit_burst %} burst={{ route.ratelimit_burst }}{% endif %}{% if route.ratelimit_delay %} delay={{ route.ratelimit_delay }}{% endif %}{% if route.ratelimit_nodelay %} nodelay{% endif %};
-            limit_req_status {{ route.ratelimit_status | default(429) }};
+            {% if route.ratelimit %}
+            limit_req zone={{ route.ratelimit.zone }}{% if route.ratelimit.burst %} burst={{ route.ratelimit.burst }}{% endif %}{% if route.ratelimit.delay %} delay={{ route.ratelimit.delay }}{% endif %}{% if route.ratelimit.nodelay %} nodelay{% endif %};
+            limit_req_status {{ route.ratelimit.status | default(429) }};
             {% endif %}
             {% if route.endpoints %}
             proxy_next_upstream off;


### PR DESCRIPTION
Follow up to #37 - the configuration set on the route wasn't making it through, I think because it needs to be explicitly plumbed with a type in the config hydration step. I took this opportunity to make the ratelimit configuration its own nested structure.

I still can't run this locally, so this is mostly an implementation by dead reckoning and extending the existing code.