### PR TITLE
Inlcude ZooKeeper serverset member name in endpoint comparisons

### DIFF
--- a/tellapart/aurproxy/config/endpoint.py
+++ b/tellapart/aurproxy/config/endpoint.py
@@ -62,13 +62,16 @@ class ShareEndpoint(AuditableEndpointBase):
 
 class SourceEndpoint(EndpointBase):
   def __unicode__(self):
-    return '{0}:{1}'.format(self._host, self.port)
+    unicode = '{0}:{1}'.format(self._host, self.port)
+    if 'name' in self.context:
+        unicode = '{0} ({1})'.format(unicode, self.context['name'])
+    return unicode
 
   def __hash__(self):
     return int(hashlib.md5(self.__unicode__()).hexdigest(), 16)
 
   def __eq__(self, other):
     if self.host == other.host and self.port == other.port:
-      return True
+      return self._context.get('name', None) == other.context.get('name', None)
     else:
       return False

--- a/tellapart/aurproxy/config/endpoint.py
+++ b/tellapart/aurproxy/config/endpoint.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import hashlib
-
 class EndpointBase(object):
   def __init__(self, host, port, context=None):
     self._host = host
@@ -61,17 +59,14 @@ class ShareEndpoint(AuditableEndpointBase):
     return self._share
 
 class SourceEndpoint(EndpointBase):
-  def __unicode__(self):
-    unicode = '{0}:{1}'.format(self._host, self.port)
-    if 'name' in self.context:
-        unicode = '{0} ({1})'.format(unicode, self.context['name'])
-    return unicode
+  @property
+  def _hash_key(self):
+    return (self.host,
+            self.port,
+            self.context.get('name'))
 
   def __hash__(self):
-    return int(hashlib.md5(self.__unicode__()).hexdigest(), 16)
+    return hash(self._hash_key)
 
   def __eq__(self, other):
-    if self.host == other.host and self.port == other.port:
-      return self._context.get('name', None) == other.context.get('name', None)
-    else:
-      return False
+    return self._hash_key == other._hash_key

--- a/tellapart/aurproxy/source/source.py
+++ b/tellapart/aurproxy/source/source.py
@@ -55,9 +55,10 @@ class ProxySource(object):
 
   def add(self, endpoint):
     if endpoint not in self._endpoints:
-      logger.info('Adding endpoint: %(host)s:%(port)s',
+      logger.info('Adding endpoint: %(host)s:%(port)s %(ctx)s',
                   {'host': endpoint.host,
-                   'port': endpoint.port})
+                   'port': endpoint.port,
+                   'ctx': endpoint.context})
       self._endpoints.add(endpoint)
       self._execute_callbacks(callbacks=self._on_add_fns,
                               source=self,
@@ -65,15 +66,17 @@ class ProxySource(object):
       if self._signal_update_fn:
         self._signal_update_fn()
     else:
-      logger.info('Not adding endpoint - already known. %(host)s:%(port)s',
+      logger.info('Not adding endpoint - already known. %(host)s:%(port)s %(ctx)s',
                   {'host': endpoint.host,
-                   'port': endpoint.port})
+                   'port': endpoint.port,
+                   'ctx': endpoint.context})
 
   def remove(self, endpoint):
     if endpoint in self._endpoints:
-      logger.info('Removing endpoint: %(host)s:%(port)s',
+      logger.info('Removing endpoint: %(host)s:%(port)s %(ctx)s',
                   {'host': endpoint.host,
-                   'port': endpoint.port})
+                   'port': endpoint.port,
+                   'ctx': endpoint.context})
       self._endpoints.remove(endpoint)
       self._execute_callbacks(callbacks=self._on_remove_fns,
                               source=self,
@@ -81,9 +84,10 @@ class ProxySource(object):
       if self._signal_update_fn:
         self._signal_update_fn()
     else:
-      logger.info('Not removing endpoint - not known. %(host)s:%(port)s',
+      logger.info('Not removing endpoint - not known. %(host)s:%(port)s %(ctx)s',
                   {'host': endpoint.host,
-                   'port': endpoint.port})
+                   'port': endpoint.port,
+                   'ctx': endpoint.context})
 
   def register_on_add(self, fn):
     self._on_add_fns.append(fn)

--- a/tellapart/aurproxy/source/sources/serverset.py
+++ b/tellapart/aurproxy/source/sources/serverset.py
@@ -83,7 +83,8 @@ class ServerSetSource(ProxySource):
       port_map[k] = v.port
     return SourceEndpoint(host=ep.host,
                           port=ep.port,
-                          context={'port_map': port_map})
+                          context={'port_map': port_map,
+                                   'name': service_instance.name})
 
   def _get_kazoo_client(self):
     kc = KazooClient(


### PR DESCRIPTION
## Description

Using the ZooKeeper ServerSetSource, if service instances crash and restart on the same host:port it can lead to all endpoints for the service being removed and a total outage to clients, due to the following sequence of events:

* A service instance crashes and does not cleanly remove itself from the serverset, leaving a "zombie" member.
* A service instance starts on the same host:port and registers itself in the serverset as a new member.
* ServerSetSource is notified of the new serverset member, but ignores it because that host:port is already present in the same source.
* The ZK node of the crashed service instance is deleted, presumably because its ZK session expires.
* ServerSetSource is notified of the removed serverset member. It removes the endpoint, leaving no endpoints for the service at all.

This has shown up with this sequence of log events:

```
2024-07-09 19:01:23,323 [INFO] tellapart.aurproxy.source.source: Adding endpoint: 10.52.64.35:80
2024-07-10 02:03:47,672 [INFO] tellapart.aurproxy.source.source: Not adding endpoint - already known. 10.52.64.35:80
2024-07-10 02:04:05,715 [INFO] tellapart.aurproxy.source.source: Removing endpoint: 10.52.64.35:80
2024-07-10 13:46:56,305 [INFO] tellapart.aurproxy.source.source: Not removing endpoint - not known. 10.52.64.35:80
```

## Changes

The problem is that the ProxySource logic endpoint objects adds Endpoint objects to a set:

https://github.com/amperity/aurproxy/blob/d97261f56370886c8302071d9e66587284160f90/tellapart/aurproxy/source/source.py#L56-L86

however Endpoints are only compared based on host:port:

https://github.com/amperity/aurproxy/blob/d97261f56370886c8302071d9e66587284160f90/tellapart/aurproxy/config/endpoint.py#L63-L74

To fix the issue we can include a unique key in that comparison that distinguishes the old service instance from the new service instance. For a ZK serverset we can include the ZK node name, also know as the serverset member name. If members are created as sequential nodes then ZK guarantees their names are unique, with monotonically increasing suffixes (https://zookeeper.apache.org/doc/r3.5.4-beta/zookeeperProgrammers.html#Sequence+Nodes+--+Unique+Naming).

Also added the endpoint context map, which includes the unique key, to logging in ProxySource add and remove logic.