### PR TITLE
Pipe access logs to stdout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   python:
     docker:
-      - image: circleci/python:2.7.13
+      - image: cimg/python:2.7.18
     working_directory: ~/repo
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           name: "Install venv and run tests"
           command: |
             pip install virtualenv
-            virtualenv -p python2.7 --no-site-packages --distribute ~/.virtualenvs/aurproxy
+            virtualenv -p python2.7 ~/.virtualenvs/aurproxy
             source ~/.virtualenvs/aurproxy/bin/activate
             pip install -r requirements.txt
             pip install -r requirements_dev.txt

--- a/templates/nginx/nginx.conf.template
+++ b/templates/nginx/nginx.conf.template
@@ -36,7 +36,7 @@ http {
                                      '$upstream_response_time '
                                      '"$upstream_addr" $msec';
 
-    access_log stdout combined_forwarded_ip;
+    access_log /dev/stdout combined_forwarded_ip;
     error_log stderr;
 
     {% if context.gzip -%}
@@ -72,7 +72,7 @@ http {
         }
         location /aurproxy/status {
             stub_status on;
-            access_log stdout;
+            access_log /dev/stdout;
             {% if context.internal_source_cidr %}
             allow {{ context.internal_source_cidr }};
             {%- endif %}
@@ -91,7 +91,7 @@ http {
             echo "Error";
         }
         location / {
-            access_log stderr;
+            access_log /dev/stdout;
             return 502;
         }
     }
@@ -128,7 +128,7 @@ http {
         }
 
         {% if server.healthcheck_route %}location {{ server.healthcheck_route }} {
-          access_log stdout;
+          access_log /dev/stdout;
           return 200;
         }
         {% endif %}
@@ -163,7 +163,7 @@ http {
             proxy_pass http://{{ server.slug }}{{ route.slug }}{{ route.proxy_path or "" }};
             {% else %}
             # No endpoints found for {{ server.slug }}{{ route.slug }}
-            access_log stdout;
+            access_log /dev/stdout;
             return {{ route.empty_endpoint_status_code }};
             {% endif %}
         }

--- a/templates/nginx/nginx.conf.template
+++ b/templates/nginx/nginx.conf.template
@@ -36,7 +36,7 @@ http {
                                      '$upstream_response_time '
                                      '"$upstream_addr" $msec';
 
-    access_log /dev/stdout combined_forwarded_ip;
+    access_log stdout combined_forwarded_ip;
     error_log stderr;
 
     {% if context.gzip -%}
@@ -72,7 +72,7 @@ http {
         }
         location /aurproxy/status {
             stub_status on;
-            access_log on;
+            access_log stdout;
             {% if context.internal_source_cidr %}
             allow {{ context.internal_source_cidr }};
             {%- endif %}
@@ -91,7 +91,7 @@ http {
             echo "Error";
         }
         location / {
-            access_log on;
+            access_log stderr;
             return 502;
         }
     }
@@ -128,7 +128,7 @@ http {
         }
 
         {% if server.healthcheck_route %}location {{ server.healthcheck_route }} {
-          access_log on;
+          access_log stdout;
           return 200;
         }
         {% endif %}
@@ -163,7 +163,7 @@ http {
             proxy_pass http://{{ server.slug }}{{ route.slug }}{{ route.proxy_path or "" }};
             {% else %}
             # No endpoints found for {{ server.slug }}{{ route.slug }}
-            access_log on;
+            access_log stdout;
             return {{ route.empty_endpoint_status_code }};
             {% endif %}
         }


### PR DESCRIPTION
We recently saw some instances of web-aurproxy fail with disk limit errors. It looks like our access logs are being written to an `on` file that doesn't get rotated by aurora because in our nginx template we specify the path as literally `on`.

Let's have our access logs write to stdout instead so aurora can logrotate them properly.