### PR TITLE
Fix failing aurproxy CI tests

### DIFF
--- a/tellapart/aurproxy/config/endpoint.py
+++ b/tellapart/aurproxy/config/endpoint.py
@@ -69,4 +69,4 @@ class SourceEndpoint(EndpointBase):
     return hash(self._hash_key)
 
   def __eq__(self, other):
-    return self._hash_key == other._hash_key
+    return isinstance(other, SourceEndpoint) and self._hash_key == other._hash_key

--- a/tellapart/aurproxy/config/endpoint.py
+++ b/tellapart/aurproxy/config/endpoint.py
@@ -69,4 +69,4 @@ class SourceEndpoint(EndpointBase):
     return hash(self._hash_key)
 
   def __eq__(self, other):
-    self.__hash__ == other.__hash__
+    return self.host == other.host and self.port == other.port and self.context.get('name') == other.context.get('name')

--- a/tellapart/aurproxy/config/endpoint.py
+++ b/tellapart/aurproxy/config/endpoint.py
@@ -69,4 +69,4 @@ class SourceEndpoint(EndpointBase):
     return hash(self._hash_key)
 
   def __eq__(self, other):
-    return isinstance(other, SourceEndpoint) and self._hash_key == other._hash_key
+    hash(self) == hash(other)

--- a/tellapart/aurproxy/config/endpoint.py
+++ b/tellapart/aurproxy/config/endpoint.py
@@ -69,4 +69,4 @@ class SourceEndpoint(EndpointBase):
     return hash(self._hash_key)
 
   def __eq__(self, other):
-    hash(self) == hash(other)
+    self.__hash__ == other.__hash__


### PR DESCRIPTION
These tests continued to fail because we recently changed `SourceEndpoint` to check for equality be comparing the `_hash_key` attributes, but not all of the endpoint classes have this attribute implemented. Let's just check for what we care about directly, and confirm that the host, port, and context names are equal.