### PR TITLE
[BASS-3653] Aurproxy should explicitly try to register itself into the aurora backend pool, and not just the first backend pool it finds

### DIFF
--- a/tellapart/aurproxy/register/azurelb.py
+++ b/tellapart/aurproxy/register/azurelb.py
@@ -111,7 +111,7 @@ class BaseAzureLbRegisterer(AzureRegisterer):
     if not vm:
         logger.warn('no vm to register!')
         return False
-    bp = self._find_backend_pool(lb, None)
+    bp = self._find_backend_pool(lb, 'aurora')
     match = self._match_ip_config(vm)
     if not match or not bp:
         logger.warn('failed to find nic without pooling ip config for this vm!')


### PR DESCRIPTION
[BASS-3653](https://amperity.atlassian.net/browse/BASS-3653)
We don’t provide aurproxy the name of the backend pool we want the current vm to be added to, so it just defaults to the first backend pool the azure api returns. This causes problems when we try to have aurproxy share an application gateway with kubernetes, since aurproxy will add itself to the k8s backend pool instead of the aurora backend pool which messes up any routing rules we've configured (and would probably take down the app after an aurproxy deploy rip).

Fortunately this looks like a pretty easy one line change. I'll test this out in az-stage afterward to verify it's all correct to unblock my work to move streaming-ingest off aurproxy.