### PR TITLE
Update the right registration class to add aurproxy instances to the right Azure backend pool

### DIFF
--- a/tellapart/aurproxy/register/azurelb.py
+++ b/tellapart/aurproxy/register/azurelb.py
@@ -309,7 +309,7 @@ class AzureGatewaySelfRegisterer(AzureRegisterer):
     if not vm:
         logger.warn('no vm to register!')
         return False
-    bp = self._find_backend_pool(lb, None)
+    bp = self._find_backend_pool(lb, 'aurora')
     match = self._match_ip_config(vm)
     if not match or not bp:
         logger.warn('failed to find nic without pooling ip config for this vm!')


### PR DESCRIPTION
Follow up to https://github.com/amperity/aurproxy/pull/44, turns out I had missed one spot to set the backend pool name since we don't currently use the `BaseAzureLbRegisterer` in our aurproxy config. I also needed to update the `AzureGatewaySelfRegisterer` class to explicitly use the `aurora` backend pool